### PR TITLE
Add nf-prov plugin

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -2,14 +2,12 @@
 * This configuration file is the default one used by the pipeline
 */
 
-
 process.container = 'ghcr.io/mc2-center/nf-histoqc:latest'
 
 docker{
     enabled = true
     runOptions = '-u $(id -u):$(id -g)'
 }
-
 
 profiles{
     test { includeConfig 'conf/test.config'}
@@ -29,3 +27,13 @@ profiles{
         }
     }
 }
+
+plugins {
+    id 'nf-prov'
+  }
+  
+  prov {
+      enabled = true
+      overwrite = true
+      file = "${params.outDir}/manifest.json"
+  }

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,8 +32,8 @@ plugins {
     id 'nf-prov'
   }
   
-  prov {
-      enabled = true
-      overwrite = true
-      file = "${params.outDir}/manifest.json"
+prov {
+    enabled = true
+    overwrite = true
+    file = "${params.outDir}/manifest.json"
   }


### PR DESCRIPTION
Adds the nf-prov plugin to the nextflow.config.
This will output a BCO compatiable manifest.json file into the outDir with information on the pipeline provenance.

See https://github.com/nextflow-io/nf-prov for details