### PR TITLE
Reduce tower profile resource allocation

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -16,8 +16,8 @@ profiles{
     sage { includeConfig 'conf/sage.config'}
     tower{
         process {
-            cpus = {4 * task.attempt}
-            memory = {16.GB * task.attempt}
+            cpus = {2 * task.attempt}
+            memory = {10.GB * task.attempt}
             maxRetries = 3
             errorStrategy = 'retry'
         }


### PR DESCRIPTION
Based on a run of 1000+ TCGA BRCA images this reduces the CPU and memory allocation