### PR TITLE
Simplfy histoqc module

### DIFF
--- a/modules/histoqc.nf
+++ b/modules/histoqc.nf
@@ -17,11 +17,8 @@ process HISTOQC {
     beforeScript 'chmod g+w .'
     
     script:
-    // 'default' is not a named config so we use conditional 
-    // scripts to skip the config variable if it should be default  
-    def config_var = (params.config == 'default') ? "" : "-c $params.config" // Define config_var here
     """
-    python -m histoqc ${config_var} $images -o out
+    python -m histoqc -c ${params.config} $images -o out
     mv out/$images/*.png .
     """
 }

--- a/modules/histoqc.nf
+++ b/modules/histoqc.nf
@@ -8,8 +8,8 @@ process HISTOQC {
     tuple val(meta), path(images)
 
     output:
-    path "${images.simpleName}_out/results.tsv", emit: results
-    path "${images.simpleName}_out/error.log", emit: errors
+    path "out/results.tsv", emit: results
+    path "out/error.log", emit: errors
     path "*.png", emit: masks
 
     // Need to set permissions for the non-root docker user 
@@ -18,15 +18,10 @@ process HISTOQC {
     
     script:
     // 'default' is not a named config so we use conditional 
-    // scripts to skip the config variable if it should be default
-    if (params.config == 'default')
-        """
-        python -m histoqc $images -o ${images.simpleName}_out
-        mv ${images.simpleName}_out/$images/*.png .
-        """
-    else
-        """
-        python -m histoqc -c $params.config $images -o ${images.simpleName}_out
-        mv ${images.simpleName}_out/$images/*.png .
-        """
+    // scripts to skip the config variable if it should be default  
+    def config_var = (params.config == 'default') ? "" : "-c $params.config" // Define config_var here
+    """
+    python -m histoqc ${config_var} $images -o out
+    mv out/$images/*.png .
+    """
 }


### PR DESCRIPTION
Thanks to feedback from Brad MacDonald in code review, this PR simplifies the histoqc.nf module file by transforming params$config to a new variable $config_var which is “-c $params.config” when $params.config is not default and an empty string when default. This then allows for a single rather than conditional script section.

I also fix the name of the HistoQC output directory within the process