### PR TITLE
Remove beforeScript that set docker permissions (not-needed)

### DIFF
--- a/modules/histoqc.nf
+++ b/modules/histoqc.nf
@@ -11,10 +11,6 @@ process HISTOQC {
     path "${images.simpleName}_out/results.tsv", emit: results
     path "${images.simpleName}_out/error.log", emit: errors
     path "*.png", emit: masks
-
-    // Need to set permissions for the non-root docker user 
-    // See https://github.com/InformaticsMatters/pipelines/issues/22
-    beforeScript 'chmod g+w .'
     
     script:
     // 'default' is not a named config so we use conditional 

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,6 @@ process.container = 'ghcr.io/mc2-center/nf-histoqc:latest'
 
 docker{
     enabled = true
-    runOptions = '-u $(id -u):$(id -g)'
 }
 
 


### PR DESCRIPTION
Removing the beforeScript that set docker permissions as it seems to not be needed. (Local tests passing, will test on tower)