### PR TITLE
Add openslide converter

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -4,6 +4,15 @@ nextflow.enable.dsl=2
 
 if (params.input) { params.input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
 
+params.convert = false
+
+if (params.convert) {
+    if (!params.mag || !params.mpp) {
+        error "Both nominal magnification ('mag') and microns per pixel ('mpp' parameters must be provided when 'params.convert' is set to true."
+    }
+}
+
+
 // Set parameters and defaults
 params.outDir = './outputs'
 params.config = 'default'

--- a/modules/convert_to_openslide.nf
+++ b/modules/convert_to_openslide.nf
@@ -1,0 +1,17 @@
+process CONVERT {
+
+    container 'ghcr.io/mc2-center/histoqc-openslide-converter:latest'
+
+    input:
+    tuple val(meta), path(images)
+
+    output:
+    tuple val(meta), path("${images.simpleName}_openslide.tiff")
+
+    script:
+
+    """
+    vips im_vips2tiff $images ${images.simpleName}_openslide.tiff:jpeg:75,tile:512x512,pyramid
+    tifftools set -y -s ImageDescription  "Aperio nf-histoqc |AppMag = $params.mag|MPP = $params.mpp" ${images.simpleName}_openslide.tiff
+    """
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -42,7 +42,7 @@
     "conversion_options": {
       "title": "Conversion options",
       "type": "object",
-      "fa_icon": "fas fa-solid fa-rotate-right",
+      "fa_icon": "fas fa-solid fa-magic",
       "description": "Define parameters used during conversion to openslide compatible tiff",
       "properties": {
         "convert": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -44,6 +44,7 @@
       "type": "object",
       "fa_icon": "fas fa-solid fa-magic",
       "description": "Define parameters used during conversion to openslide compatible tiff",
+      "hidden": true,
       "properties": {
         "convert": {
             "type": "boolean",
@@ -55,7 +56,7 @@
         },
         "mpp": {
           "type": "number",
-          "description": "Image resolution (pixels per micron) to inject into openslide compatible tiff"
+          "description": "Image resolution (microns per pixel) to inject into openslide compatible tiff"
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -44,19 +44,21 @@
       "type": "object",
       "fa_icon": "fas fa-solid fa-magic",
       "description": "Define parameters used during conversion to openslide compatible tiff",
-      "hidden": true,
       "properties": {
         "convert": {
             "type": "boolean",
-            "description": "Should images be converted to an openslide compatible tiff"
+            "description": "Should images be converted to an openslide compatible tiff",
+            "hidden": true
         },
         "mag": {
             "type": "integer",
-            "description": "Nominal magnification to inject into openslide compatible tiff"
+            "description": "Nominal magnification to inject into openslide compatible tiff",
+            "hidden": true
         },
         "mpp": {
           "type": "number",
-          "description": "Image resolution (microns per pixel) to inject into openslide compatible tiff"
+          "description": "Image resolution (microns per pixel) to inject into openslide compatible tiff",
+          "hidden": true
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -38,6 +38,26 @@
           "enum": ["default", "ihc", "clinical", "first", "light", "v2.1"]
         }
       }
+    },
+    "conversion_options": {
+      "title": "Conversion options",
+      "type": "object",
+      "fa_icon": "fas fa-solid fa-rotate-right",
+      "description": "Define parameters used during conversion to openslide compatible tiff",
+      "properties": {
+        "convert": {
+            "type": "boolean",
+            "description": "Should images be converted to an openslide compatible tiff"
+        },
+        "mag": {
+            "type": "integer",
+            "description": "Nominal magnification to inject into openslide compatible tiff"
+        },
+        "mpp": {
+          "type": "number",
+          "description": "Image resolution (pixels per micron) to inject into openslide compatible tiff"
+        }
+      }
     }
   },
   "allOf": [

--- a/subworkflows/run_histoqc.nf
+++ b/subworkflows/run_histoqc.nf
@@ -8,7 +8,7 @@ workflow RUN {
 
     main:
 
-    images | (params.convert ? CONVERT : it) | HISTOQC
+    ifparams.convert ? CONVERT(images) | HISTOQC : HISTOQC(images)
 
     emit:
     output = HISTOQC.out.masks

--- a/subworkflows/run_histoqc.nf
+++ b/subworkflows/run_histoqc.nf
@@ -1,4 +1,5 @@
 include { HISTOQC } from "../modules/histoqc.nf"
+include { CONVERT } from "../modules/convert_to_openslide.nf"
 
 workflow RUN {
     
@@ -6,7 +7,8 @@ workflow RUN {
     images
 
     main:
-    HISTOQC ( images ) 
+
+    images | (params.convert ? CONVERT : it) | HISTOQC
 
     emit:
     output = HISTOQC.out.masks

--- a/subworkflows/run_histoqc.nf
+++ b/subworkflows/run_histoqc.nf
@@ -8,7 +8,7 @@ workflow RUN {
 
     main:
 
-    ifparams.convert ? CONVERT(images) | HISTOQC : HISTOQC(images)
+    params.convert ? CONVERT(images) | HISTOQC : HISTOQC(images)
 
     emit:
     output = HISTOQC.out.masks


### PR DESCRIPTION
This PR adds the functionality to convert input images to an openslide compatible tiff and add minimal metadata as required to use HistoQC.

Closes #22 