### PR TITLE
Group outputs in subdirs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,8 @@ if ( params.custom_config ) {
 params.outDir = './outputs'
 params.config = 'default'
 
+params.group = false
+
 // Import workflow
 include { NF_HISTOQC } from './workflows/nf_histoqc.nf'
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -43,6 +43,10 @@
           "format": "file-path",
           "mimetype": "text/plain",
           "description": "Path to a HistoQC config `.ini` file. Overrides `config`"
+        },
+        "output_grouping": {
+          "type": "boolean",
+          "description": "Arrange outputs into subfolders defined by the samplesheet `group` column"
         }
       }
     },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -44,7 +44,8 @@
           "mimetype": "text/plain",
           "description": "Path to a HistoQC config `.ini` file. Overrides `config`"
         },
-        "output_grouping": {
+        "group": {
+          "title": "Output grouping",
           "type": "boolean",
           "description": "Arrange outputs into subfolders defined by the samplesheet `group` column"
         }

--- a/subworkflows/samplesheet_split.nf
+++ b/subworkflows/samplesheet_split.nf
@@ -14,6 +14,9 @@ workflow SPLIT {
             } else {
                 meta.id = file(row.image).simpleName
             }
+            if (row.group && params.group) {
+                meta.group = row.group
+            }
             image = file(row.image)
             [meta, image]
         }

--- a/test_data/test_samplesheet.csv
+++ b/test_data/test_samplesheet.csv
@@ -1,3 +1,3 @@
-image
-test_data/CMU-1-Small-Region.svs
-test_data/CMU-1-Small-Region-copy.svs
+id,group,image
+small,group1,test_data/CMU-1-Small-Region.svs
+copy,group2,test_data/CMU-1-Small-Region-copy.svs


### PR DESCRIPTION
In large runs it may be advantagous to group outputs into subdirectories.

This PR adds this ability.

When `param.group` is `true` and a column `group` is added to the samplesheet the outputs are nested under folders named after the relevant group. 

The group is also added as a directory to the results file